### PR TITLE
Adds Doctave under Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 
 ## Hosting
 
+- [Doctave](https://www.doctave.com/)
 - [GitBook](https://www.gitbook.com/)
 - [Netlify](https://www.netlify.com/)
 - [Read The Docs](https://readthedocs.org/)


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description

Hey there 👋 Thanks for maintaining this list!

Wanted to submit [Doctave](https://www.doctave.com) under the "Hosting" category - it's a docs hosting platform focused on docs-as-code.

Do let me know if I missed anything here. I assumed alphabetical ordering for the lists.
