### PR TITLE
Remove Alphadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 
 ## Hosting
 
-- [Alphadoc](https://www.alphadoc.io/)
 - [Doctave](https://www.doctave.com/)
 - [GitBook](https://www.gitbook.com/)
 - [Netlify](https://www.netlify.com/)


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Remove Alphadoc

Removes Alphadoc from the Hosting category, as Alphadoc services have been shut down on 16 August 2024. 

Per their mainpage at https://alphadoc.io

