### PR TITLE
Add Hashnode to the Hosting providers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 ## Hosting
 
 - [Doctave](https://www.doctave.com/)
+- [Docs by Hashnode](https://hashnode.com/products/docs)
 - [GitBook](https://www.gitbook.com/)
 - [Mintlify](https://www.mintlify.com/)
 - [Netlify](https://www.netlify.com/)


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description

Hashnode now lets developers create and host product and API documentation. They can add multiple guides and API references within a single project, and even launch a blog to build a developer hub for their brand.