### PR TITLE
Add Xquik API documentation and alphabetize the API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [Tips for better documentation with OpenAPI](https://lornajane.net/posts/2023/tips-for-better-documentation-with-openapi)
 - [What we can learn from UX professionals when designing APIs](https://www.linkedin.com/pulse/what-we-can-learn-from-ux-professionals-when-designing-joyce-stack-/)
 - [widdershins](https://github.com/Mermade/widdershins)
+- [Xquik API Documentation](https://docs.xquik.com) - REST API documentation for the Xquik X/Twitter automation platform. Covers 40+ API endpoints, MCP server setup, webhook integration, OpenAPI spec, and interactive examples.
 - [Zalando RESTful API and Event Guidelines](https://opensource.zalando.com/restful-api-guidelines/#)
 
 ## Browser Extensions

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [API Guidelines](https://dret.github.io/guidelines/)
 - [Bruno](https://www.usebruno.com/)
 - [Bump.sh](https://bump.sh/)
+- [DevDocsAI](https://devdocsai-sigma.vercel.app/) - AI-powered API documentation generator. Paste code, get docs in 30 seconds.
 - [Document360 API Documentation](https://document360.com/solutions/api-documentation/)
 - [Hoppscotch](https://github.com/hoppscotch/hoppscotch)
 - [json-schema-sensitivity-checker](https://github.com/cbetta/json-schema-sensitivity-checker)
@@ -71,8 +72,8 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [OpenAPI 3 CLI](https://github.com/Redocly/openapi-cli)
 - [Postman](https://www.getpostman.com/)
 - [RapiDoc](https://mrin9.github.io/RapiDoc/index.html)
-- [Redoc-Editor](https://github.com/pointnet/redoc-editor)
 - [ReDoc](https://redocly.github.io/redoc/)
+- [Redoc-Editor](https://github.com/pointnet/redoc-editor)
 - [Restish](https://rest.sh/#/)
 - [Sourcey](https://sourcey.com) - Static documentation generator that combines OpenAPI references with markdown guides into a single site.
 - [Speccy](https://github.com/wework/speccy)
@@ -85,7 +86,6 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [widdershins](https://github.com/Mermade/widdershins)
 - [Xquik API Documentation](https://docs.xquik.com/) - Documentation for Xquik's X data and automation API, MCP server, webhooks, and workflows.
 - [Zalando RESTful API and Event Guidelines](https://opensource.zalando.com/restful-api-guidelines/#)
-- [DevDocsAI](https://devdocsai-sigma.vercel.app/) - AI-powered API documentation generator. Paste code, get docs in 30 seconds.
 
 ## Browser Extensions
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [Tips for better documentation with OpenAPI](https://lornajane.net/posts/2023/tips-for-better-documentation-with-openapi)
 - [What we can learn from UX professionals when designing APIs](https://www.linkedin.com/pulse/what-we-can-learn-from-ux-professionals-when-designing-joyce-stack-/)
 - [widdershins](https://github.com/Mermade/widdershins)
+- [Xquik API Documentation](https://docs.xquik.com/) - Documentation for Xquik's X data and automation API, MCP server, webhooks, and workflows.
 - [Zalando RESTful API and Event Guidelines](https://opensource.zalando.com/restful-api-guidelines/#)
 - [DevDocsAI](https://devdocsai-sigma.vercel.app/) - AI-powered API documentation generator. Paste code, get docs in 30 seconds.
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description

- Add Xquik API Documentation to the API section.
- Describe the current REST, OpenAPI, MCP, webhook, and workflow documentation.
- Alphabetize all 25 API entries, contributing to #28.

The independent ordering fix moves DevDocsAI and corrects the ReDoc ordering. It remains separate from the Xquik addition.

## Validation

- Confirmed the complete API section sorts alphabetically.
- Confirmed all 4 affected links return HTTP 200.
- Confirmed one Xquik entry and one DevDocsAI entry.
- Confirmed the branch is based on current `main`.
- Confirmed both commits are signed and GitHub-verified.
- Ran `git diff --check`.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.