### PR TITLE
Add Jamdesk to Hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [Doctave](https://www.doctave.com/)
 - [Ferndesk](https://ferndesk.com/)
 - [GitBook](https://www.gitbook.com/)
+- [Jamdesk](https://www.jamdesk.com/)
 - [Mintlify](https://www.mintlify.com/)
 - [Netlify](https://www.netlify.com/)
 - [Read The Docs](https://readthedocs.org/)


### PR DESCRIPTION
# Pull Request

## Description

Hey! I'm Geoff, one of the founders of Jamdesk. It's a docs-as-code platform -- you write MDX in your repo, push to GitHub, and we build + host the site. Comes with a CLI for local dev, AI-powered search, and 50+ built-in components.

Our own docs are built with it: https://jamdesk.com/docs

Would love to be included on the list.

- Website: https://www.jamdesk.com
- CLI on npm: https://www.npmjs.com/package/jamdesk