### PR TITLE
Add MacMD Viewer to Viewer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 ## Viewer
 
 - [Glow - Render Markdown on the CLI](https://github.com/charmbracelet/glow)
+- [MacMD Viewer](https://macmdviewer.com) - Native macOS Markdown viewer with Mermaid diagram support, QuickLook extension, and syntax highlighting for 190+ languages.
 - [mdv](https://github.com/xrfang/mdv/)
 
 ## Watching


### PR DESCRIPTION
Adding MacMD Viewer as a GUI Markdown viewer for macOS. The Viewer section currently lists CLI tools (Glow, mdv) — MacMD Viewer adds a native GUI option with Mermaid diagram rendering and a QuickLook extension.