### PR TITLE
Add Sourcey

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [Redoc-Editor](https://github.com/pointnet/redoc-editor)
 - [ReDoc](https://redocly.github.io/redoc/)
 - [Restish](https://rest.sh/#/)
+- [Sourcey](https://sourcey.com) - Static documentation generator that combines OpenAPI references with markdown guides into a single site.
 - [Speccy](https://github.com/wework/speccy)
 - [Spectral](https://stoplight.io/open-source/spectral/)
 - [Stoplight Studio](https://stoplight.io/studio/)


### PR DESCRIPTION
Adds Sourcey — static documentation generator for OpenAPI and markdown.

https://sourcey.com
https://github.com/sourcey/sourcey