### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 
 ## AsciiDoc
 
+- [adoc Studio](https://adoc-studio.app)
 - [Asciidoctor](https://asciidoctor.org/)
 - [AsciiDoc Alive](https://asciidocalive.docswriter.com/)
 - [IntelliJ AsciiDoc Plugin](https://intellij-asciidoc-plugin.ahus1.de/)


### PR DESCRIPTION
added adoc Studio, a documentation app for AsciiDoc on Mac & iPad, to the list