### PR TITLE
Add AutomaDocs to Tool Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,8 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 ## Tool Collection
 
 - [adr-tools](https://github.com/npryce/adr-tools)
-- [Awesome Design Tools](https://github.com/goabstract/Awesome-Design-Tools)
 - [AutomaDocs](https://automadocs.com) - AI documentation platform for GitHub repos. Tree-sitter AST chunking, Claude generation, hybrid retrieval (BM25 + Pinecone vector). Webhook-driven selective regeneration on every push so docs stay in sync with code.
+- [Awesome Design Tools](https://github.com/goabstract/Awesome-Design-Tools)
 - [Bluehawk](https://mongodb-university.github.io/Bluehawk/)
 - [Calculate max length for UI elements](https://max-char-length-calculator.netlify.app/)
 - [Code Hike](https://codehike.org/)

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 
 - [adr-tools](https://github.com/npryce/adr-tools)
 - [Awesome Design Tools](https://github.com/goabstract/Awesome-Design-Tools)
+- [AutomaDocs](https://automadocs.com) - AI documentation platform for GitHub repos. Tree-sitter AST chunking, Claude generation, hybrid retrieval (BM25 + Pinecone vector). Webhook-driven selective regeneration on every push so docs stay in sync with code.
 - [Bluehawk](https://mongodb-university.github.io/Bluehawk/)
 - [Calculate max length for UI elements](https://max-char-length-calculator.netlify.app/)
 - [Code Hike](https://codehike.org/)


### PR DESCRIPTION
Hi maintainers,

Adding [AutomaDocs](https://automadocs.com) to the **Tool Collection** section, alphabetically between Awesome Design Tools and Bluehawk.

**What it does:** AI documentation platform for GitHub repos. Tree-sitter AST chunking + Claude generation + hybrid retrieval (BM25 + Pinecone vector + RRF) with inline file:line citations.

**Sibling fits in the same section:** PitchDocs (also AI-powered code documentation generator), Trupeer (AI screen-recording → docs), readme.so.

**Differentiator:** webhook-driven selective regeneration on every git push (only re-processes changed chunks), so docs stay in sync with the code without a manual rebuild step.

**Live examples (real OSS projects, no signup required):**
- https://automadocs.com/docs/hyperium/tonic
- https://automadocs.com/docs/kubeshark/kubeshark
- https://automadocs.com/docs/GitoxideLabs/gitoxide

**Free tier:** 1 public repo + 10 generations/month, no credit card.

I read CONTRIBUTING.md and added the entry alphabetically. Happy to reword, move, or close if it is not a fit.

Thanks for maintaining this list.

— Liz