### PR TITLE
Add Sync-o (AI documentation automation for Atlassian Marketplace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [rundoc](https://gitlab.com/nul.one/rundoc)
 - [Shepherd](https://github.com/shipshapecode/shepherd)
 - [Squoosh](https://squoosh.app/)
+- [Sync-o](https://sync-o.io)
 - [Tables Generator](https://www.tablesgenerator.com/)
 - [Tools for Technical Writers](https://github.com/heyawhite/tech-writing-tools)
 - [Trupeer](https://www.trupeer.ai/) - AI-powered tool that transforms screen recordings into polished product videos and step-by-step documentation.

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [rundoc](https://gitlab.com/nul.one/rundoc)
 - [Shepherd](https://github.com/shipshapecode/shepherd)
 - [Squoosh](https://squoosh.app/)
-- [Sync-o](https://sync-o.io)
+- [Sync-o](https://sync-o.io) - AI documentation automation for Atlassian. Auto-updates Confluence pages with surgical section-level diffs when Jira tickets transition to Done. EU-resident, GDPR-compliant.
 - [Tables Generator](https://www.tablesgenerator.com/)
 - [Tools for Technical Writers](https://github.com/heyawhite/tech-writing-tools)
 - [Trupeer](https://www.trupeer.ai/) - AI-powered tool that transforms screen recordings into polished product videos and step-by-step documentation.


### PR DESCRIPTION
Adds Sync-o to the Tool Collection section.

Sync-o is an Atlassian Marketplace Forge app (https://marketplace.atlassian.com/apps/1437246984) that automatically keeps Confluence documentation in sync with Jira tickets — when a ticket transitions to Done, Sync-o detects which Confluence pages reference that ticket and drafts surgical section-level updates, with full Confluence version history and one-click revert.

Distinguishing features:
- Atlassian Forge native (no separate infra for customers)
- AWS backend in eu-west-1 (GDPR-compliant, EU-resident by default)
- BYOM AI providers: Google Vertex (default), OpenAI, Anthropic, Microsoft Azure OpenAI
- 14-day free trial; tiered per-user-per-month pricing
- Full published Trust Center (https://sync-o.io/trust), DPA (https://sync-o.io/dpa), and CAIQ Lite v4.0.3 self-assessment (https://sync-o.io/caiq-lite)