### PR TITLE
feat: add TWZRD Agent Intel to Tool Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [Shepherd](https://github.com/shipshapecode/shepherd)
 - [Squoosh](https://squoosh.app/)
 - [Sync-o](https://sync-o.io) - AI documentation automation for Atlassian. Auto-updates Confluence pages with surgical section-level diffs when Jira tickets transition to Done. EU-resident, GDPR-compliant.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - AI agent trust scoring MCP server. Verifies agent wallet identity and computes trust scores before granting AI agents access to documentation APIs or paid content services. Free tools: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 - [Tables Generator](https://www.tablesgenerator.com/)
 - [Tools for Technical Writers](https://github.com/heyawhite/tech-writing-tools)
 - [Trupeer](https://www.trupeer.ai/) - AI-powered tool that transforms screen recordings into polished product videos and step-by-step documentation.


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Tool Collection** section.

## What it does

TWZRD Agent Intel is a free MCP server for AI agent trust scoring and identity verification on Solana. It is relevant to documentation tooling as an infrastructure layer for documentation platforms that serve AI agents — letting those platforms verify agent wallet identity and trust level before granting access to paid docs APIs, RAG endpoints, or content services.

**Free tools**: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`  
**Transport**: Remote streamable-http — no local install required.  
**MCP config**: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`  
**Homepage**: https://intel.twzrd.xyz

🤖 Generated with [Claude Code](https://claude.com/claude-code)