### PR TITLE
Add Tablesmit to Tool Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [Squoosh](https://squoosh.app/)
 - [Sync-o](https://sync-o.io) - AI documentation automation for Atlassian. Auto-updates Confluence pages with surgical section-level diffs when Jira tickets transition to Done. EU-resident, GDPR-compliant.
 - [Tables Generator](https://www.tablesgenerator.com/)
-- [Tablesmit](https://tablesmit.com) - Free and open-source table builder for documentation. Create structured tables with drag-to-resize, merge cells, custom headers, and export to PDF, Excel, CSV, LaTeX, or Markdown.
+- [Tablesmit](https://tablesmit.com) - A minimalist, open-source table builder for analytical writing. It helps create, format, and export structured tables for technical documentation.
 - [Tools for Technical Writers](https://github.com/heyawhite/tech-writing-tools)
 - [Trupeer](https://www.trupeer.ai/) - AI-powered tool that transforms screen recordings into polished product videos and step-by-step documentation.
 - [vendir](https://carvel.dev/vendir/)

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [Squoosh](https://squoosh.app/)
 - [Sync-o](https://sync-o.io) - AI documentation automation for Atlassian. Auto-updates Confluence pages with surgical section-level diffs when Jira tickets transition to Done. EU-resident, GDPR-compliant.
 - [Tables Generator](https://www.tablesgenerator.com/)
+- [Tablesmit](https://tablesmit.com) - Free and open-source table builder for documentation. Create structured tables with drag-to-resize, merge cells, custom headers, and export to PDF, Excel, CSV, LaTeX, or Markdown.
 - [Tools for Technical Writers](https://github.com/heyawhite/tech-writing-tools)
 - [Trupeer](https://www.trupeer.ai/) - AI-powered tool that transforms screen recordings into polished product videos and step-by-step documentation.
 - [vendir](https://carvel.dev/vendir/)


### PR DESCRIPTION
Adds Tablesmit to the Tool Collection section — a free and open-source table builder for creating structured documentation tables.

Tablesmit is MIT licensed, actively maintained, and supports export to PDF, Excel, CSV, LaTeX, and Markdown — all common documentation formats.

Checklist:
- One entry, alphabetically sorted
- Concise, non-promotional description
- Open-source (MIT)
- Actively maintained
- Thoroughly documented in English