### PR TITLE
Add DocPulse to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 ## GitHub Actions
 
 - [Alex Action](https://github.com/theashraf/alex-action)
+- [DocPulse](https://github.com/YoniRaviv/DocPulse)
 - [DOCtor-RST](https://github.com/marketplace/actions/doctor-rst)
 - [EkLine](https://ekline.io)
 - [Lighthouse CI Action](https://github.com/treosh/lighthouse-ci-action)


### PR DESCRIPTION
Adds **DocPulse** to the *GitHub Actions* category (alphabetically, between Alex Action and DOCtor-RST).

[DocPulse](https://github.com/YoniRaviv/DocPulse) is an open-source (MIT) GitHub Action that detects documentation sections invalidated by a pull request's code changes and commits surgical, style-preserving fixes onto the PR branch. A deterministic layer (tree-sitter chunking → code↔doc link graph → diff-driven suspect selection) decides what to check; a bounded agentic layer (an LLM verifier, then a style-preserving repairer with a validation pass) decides stale-or-not and how to fix it.

Checklist against CONTRIBUTING.md:
- [x] Sorted alphabetically within the category
- [x] One link, link text is the project name
- [x] Actively maintained, MIT-licensed, thoroughly documented (README in English)
- [x] Entry style matches the section (link-only, as the other GitHub Actions entries)