### PR TITLE
Add DraftView links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 ## AsciiDoc
 
 - [adoc Studio](https://adoc-studio.app)
+- [AdocEditor](https://adoceditor.com/)
 - [Asciidoctor](https://asciidoctor.org/)
 - [AsciiDoc Alive](https://asciidocalive.docswriter.com/)
 - [IntelliJ AsciiDoc Plugin](https://intellij-asciidoc-plugin.ahus1.de/)
@@ -101,6 +102,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 
 ## Editor
 
+- [DraftView Edit](https://www.draftview.app/edit) - Paste a GitHub or GitLab file URL to edit it in DraftView and submit it back as a pull request or merge request.
 - [HackMD](https://hackmd.io/)
 - [Lapce](https://github.com/lapce/lapce)
 - [Mark Text](https://github.com/marktext/marktext)
@@ -343,6 +345,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [Code Hike](https://codehike.org/)
 - [CSS+JS Code snippets for enhancing online documentation](https://www.indoition.com/en/products/code-snippets-for-online-documentation.htm)
 - [docToolchain](https://github.com/doctoolchain/doctoolchain)
+- [DraftView](https://www.draftview.app/try) - A visual review layer for docs-as-code projects. Let contributors edit rendered documentation through a GitHub-native workflow and sync changes back as pull requests.
 - [D2 Declarative Diagramming](https://d2lang.com/)
 - [DIV Table Generator](https://divtable.com/generator/)
 - [Driver.js](https://github.com/kamranahmedse/driver.js)


### PR DESCRIPTION
## 📄 Description
This pull request adds new tools to the `README.md`.
New tools added:

**AsciiDoc Editors:**
* Added [`AdocEditor`](https://adoceditor.com/) to the list of AsciiDoc editors.

**Documentation Editors and Review Tools:**
* Added [`DraftView Edit`](https://www.draftview.app/edit-this-page), a tool for editing GitHub or GitLab files and submitting changes as pull/merge requests, to the Editor section.
* Added [`DraftView`](https://www.draftview.app/), a visual review layer for docs-as-code projects that lets contributors edit rendered documentation and sync changes via pull requests, to the tools section.