### PR TITLE
Add readme-ci to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [DOCtor-RST](https://github.com/marketplace/actions/doctor-rst)
 - [EkLine](https://ekline.io)
 - [Lighthouse CI Action](https://github.com/treosh/lighthouse-ci-action)
+- [readme-ci](https://github.com/ondraulehla/readme-ci)
 - [Run misspell with reviewdog](https://github.com/marketplace/actions/run-misspell-with-reviewdog)
 - [Spellcheck Action](https://github.com/marketplace/actions/github-spellcheck-action)
 - [TOC Generator](https://github.com/technote-space/toc-generator)


### PR DESCRIPTION
Adds [readme-ci](https://github.com/ondraulehla/readme-ci) to the GitHub Actions section (alphabetical position, matching the section's link style).

readme-ci executes the fenced code blocks in README/docs top-to-bottom in an isolated sandbox (Docker or E2B). State persists between blocks like a reader following along, and the first failing block fails CI with the exact markdown line annotated – so quickstarts can't rot silently. Optionally it can open a PR with an AI-repaired block, verified by re-running the file.

I'm the author and use it in CI on my own repositories.