### PR TITLE
Add Browser SOP Builder to Tool Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [AutomaDocs](https://automadocs.com) - AI documentation platform for GitHub repos. Tree-sitter AST chunking, Claude generation, hybrid retrieval (BM25 + Pinecone vector). Webhook-driven selective regeneration on every push so docs stay in sync with code.
 - [Awesome Design Tools](https://github.com/goabstract/Awesome-Design-Tools)
 - [Bluehawk](https://mongodb-university.github.io/Bluehawk/)
+- [Browser SOP Builder](https://github.com/max-agent-hub/browser-sop-builder) - Local-first browser tool for drafting controlled procedures and exporting Markdown without accounts or server storage.
 - [Calculate max length for UI elements](https://max-char-length-calculator.netlify.app/)
 - [Code Hike](https://codehike.org/)
 - [CSS+JS Code snippets for enhancing online documentation](https://www.indoition.com/en/products/code-snippets-for-online-documentation.htm)


### PR DESCRIPTION
## Description

Adds Browser SOP Builder to the alphabetized Tool Collection. I maintain the project and have used it to draft controlled procedures as Markdown. It is a static local-first browser tool with no account, backend, analytics, cookies, or browser storage.

Project: https://github.com/max-agent-hub/browser-sop-builder
Live builder: https://max-agent-hub.github.io/browser-sop-builder/

Validation:
- Repository and live builder return HTTP 200.
- `git diff --check` passes.
- The added line follows the one-link, concise-description, alphabetical-order, and terminal-period rules.
- `awesome-lint` reports only the repository baseline issues on pre-existing lines; none reference the added entry.