### PR TITLE
Add DocFlow to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [Alex Action](https://github.com/theashraf/alex-action)
 - [DocPulse](https://github.com/YoniRaviv/DocPulse)
 - [DOCtor-RST](https://github.com/marketplace/actions/doctor-rst)
+- [DocFlow](https://aicodedocumentationgenerator.com)
 - [EkLine](https://ekline.io)
 - [Lighthouse CI Action](https://github.com/treosh/lighthouse-ci-action)
 - [Run misspell with reviewdog](https://github.com/marketplace/actions/run-misspell-with-reviewdog)


### PR DESCRIPTION
DocFlow is a GitHub App that runs on PR merge to auto-generate README, CHANGELOG, and API docs — sits naturally in the GitHub Actions section alongside EkLine, TOC Generator, and Alex Action.

Website: https://aicodedocumentationgenerator.com

Thanks for maintaining awesome-docs!