### PR TITLE
Add notabene to Feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 
 ## Feedback
 
+- [notabene](https://github.com/z29k/notabene) - Renders a repo's Markdown/MDX as a navigable site with anchored, Google-Docs-style comments; an agent applies them as source edits and journals the changes.
 - [Papercups](https://github.com/papercups-io/papercups)
 
 ## GitHub Actions


### PR DESCRIPTION
Adds [notabene](https://github.com/z29k/notabene) to **Feedback**.

notabene is a self-hosted, MIT-licensed tool that renders a repo's Markdown/MDX as a navigable site where reviewers leave anchored, Google-Docs-style comments; an AI agent then applies those comments as source edits and journals what changed. Actively maintained, documented in English, free and open source (non-promotional).

Filed under **Feedback** as a docs review/commenting tool — happy to move it to Viewer if you'd prefer.