### PR TITLE
Add Excel to Markdown to Tool Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [D2 Declarative Diagramming](https://d2lang.com/)
 - [DIV Table Generator](https://divtable.com/generator/)
 - [Driver.js](https://github.com/kamranahmedse/driver.js)
+- [Excel to Markdown](https://exceltomd.com/excel-to-markdown) - Browser-local converter for turning XLSX, XLS, and CSV data into Markdown tables for READMEs and documentation.
 - [fixred](https://github.com/rhysd/fixred)
 - [gatsby-theme-adr](https://github.com/Lullabot/gatsby-theme-adr)
 - [Loom](https://www.loom.com/)


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description

Adds Excel to Markdown to the Tool Collection section. It converts XLSX, XLS, and CSV data locally in the browser into Markdown tables suitable for READMEs and technical documentation.

The entry is alphabetically placed, uses one link, and has a concise non-promotional description. The public converter is actively maintained and documented in English.

Disclosure: I built and operate Excel to Markdown.