### PR TITLE
Add wiki to Knowledge Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [Logseq](https://logseq.com/)
 - [Obsidian](https://obsidian.md)
 - [Specsight](https://specsight.app)
+- [wiki](https://github.com/plasma-ai/wiki) - Indexed Markdown knowledge bases for agents, with deterministic indexes, scoped retrieval, linting, and merge handling for parallel edits.
 
 ## Mockup
 


### PR DESCRIPTION
## Summary

Add [wiki](https://github.com/plasma-ai/wiki) to **Knowledge Base** in alphabetical order.

The project keeps knowledge in plain Markdown and provides deterministic indexes, scoped retrieval, linting, and merge handling for parallel edits. It is actively maintained, documented in English, and distributed under Apache-2.0.

Disclosure: I'm affiliated with the project.