### PR TITLE
Add Pushpen to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [DOCtor-RST](https://github.com/marketplace/actions/doctor-rst)
 - [EkLine](https://ekline.io)
 - [Lighthouse CI Action](https://github.com/treosh/lighthouse-ci-action)
+- [Pushpen](https://github.com/David19876543210/pushpen-action) - Generates and updates README, changelog, API docs, and onboarding guides from a repository's actual code and commit history on every push, opened as a pull request.
 - [Run misspell with reviewdog](https://github.com/marketplace/actions/run-misspell-with-reviewdog)
 - [Spellcheck Action](https://github.com/marketplace/actions/github-spellcheck-action)
 - [TOC Generator](https://github.com/technote-space/toc-generator)


### PR DESCRIPTION
Pushpen is a GitHub Action that generates and keeps README, changelog, API docs, and onboarding guides in sync with a repository's actual code and commit history — it reads the diff on every push and opens a pull request with the updated docs for review, rather than requiring a manual prompt each time.

Repo: https://github.com/David19876543210/pushpen-action