### PR TITLE
Add HTML to Markdown Converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Thanks to all [contributors](https://github.com/testthedocs/awesome-docs/graphs/
 - [Excel to Markdown](https://exceltomd.com/excel-to-markdown) - Browser-local converter for turning XLSX, XLS, and CSV data into Markdown tables for READMEs and documentation.
 - [fixred](https://github.com/rhysd/fixred)
 - [gatsby-theme-adr](https://github.com/Lullabot/gatsby-theme-adr)
+- [HTML to Markdown Converter](https://alltoolsverse.com/tools/html-to-markdown/) - Browser-local converter for turning HTML headings, lists, links, blockquotes, and inline formatting into Markdown.
 - [Loom](https://www.loom.com/)
 - [Mermaid Online](https://mermaidonline.org/) - Browser-based Mermaid diagram converter for previewing diagrams and exporting PNG, SVG, JPG, WebP, and PDF assets for docs, READMEs, blogs, and slides.
 - [Markdoc](https://markdoc.io/)


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Description

Adds HTML to Markdown Converter to the Tool Collection.

The browser-local utility turns HTML headings, lists, links, blockquotes, code, and inline formatting into Markdown.

Validation:
- Tested a real conversion with headings, bold and italic text, a link, a list, a blockquote, inline code, and a fenced code block.
- Confirmed the conversion runs locally in the browser.
- Searched the README and pull request history for duplicate URLs and equivalent entries.
- Added one canonical URL and one line in alphabetical position.

Disclosure: I am the maker of All Tools Verse. OpenAI Codex assisted with repository research, live testing, and preparing this pull request.